### PR TITLE
Add amateur setup.py

### DIFF
--- a/bfdmeds/psf.py
+++ b/bfdmeds/psf.py
@@ -251,7 +251,6 @@ class DirectoryPsfexSource(PsfexSource):
             A numpy stamp_size x stamp_size image of the PSF
 
         """
-        print("get_psf",tilename,band,exposure,ccd,row,col,stamp_size)
         fits_filename = self._get_psfex_filename(exposure, band, ccd)
         hdu_name = "PSF_DATA"
         psf_data = self._get_psf_data(fits_filename, hdu_name)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+import os
+import glob
+from distutils.core import setup, Extension
+import numpy
+
+dependencies = ['numpy', 'meds', 'astropy', 'pixmappy']
+
+setup(name="bfdmeds", 
+      version="0.1",
+      description="Wrapper around MEDS files for interfacing to BFD code and new astrometry",
+      license = "GNU GPLv3",
+      author="Daniel Gruen",
+      author_email="dgruen@stanford.edu",
+      url="https://github.com/danielgruen/bfdmeds",
+      packages=['bfdmeds'],
+      install_requires=dependencies)
+
+


### PR DESCRIPTION
Turns bfdmeds into a simple module.  Also removed a debug print statement from psf.py.  Not sure what needs to go into the dependencies declaration of the setup.py.